### PR TITLE
Add support for CDN-based bootswatch themes.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -1,7 +1,21 @@
 {% extends "basic/layout.html" %}
-{% set script_files = script_files + ['_static/js/jquery-1.9.1.min.js', '_static/js/jquery-fix.js', '_static/bootstrap-2.3.0/js/bootstrap.min.js', '_static/bootstrap-sphinx.js'] %}
-{% set css_files = ['_static/bootstrap-2.3.0/css/bootstrap.min.css', '_static/bootstrap-sphinx.css', '_static/bootstrap-2.3.0/css/bootstrap-responsive.min.css'] + css_files %}
-
+{% set script_files = script_files + [
+  '_static/js/jquery-1.9.1.min.js',
+  '_static/js/jquery-fix.js',
+  '_static/bootstrap-2.3.0/js/bootstrap.min.js',
+  '_static/bootstrap-sphinx.js']
+%}
+{% if theme_bootswatch_theme == "default" %}
+{% set css_files = [
+  'http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css',
+  '_static/bootstrap-sphinx.css'] + css_files
+%}
+{% else %}
+{% set css_files = [
+  'http://netdna.bootstrapcdn.com/bootswatch/2.3.1/' + theme_bootswatch_theme + '/bootstrap.min.css',
+  '_static/bootstrap-sphinx.css'] + css_files
+%}
+{% endif %}
 {%- block doctype -%}
 <!DOCTYPE html>
 {%- endblock %}

--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -8,6 +8,7 @@ pygments_style = tango
 [options]
 # Navigation bar title. (Default: ``project`` value)
 navbar_title =
+bootswatch_theme = default
 
 # Global TOC depth for "site" navbar tab. (Default: 1)
 # Switching to -1 shows all levels.


### PR DESCRIPTION
When a html-specific option "bootswatch_theme" is defined to one of the
values supported by http://www.bootstrapcdn.com/#tab_bootswatch then
instead of the default bootstrap look a themed, bootswatch css is used.

There are several themes to choose from as of this writing:
- amelia
- cerulean
- cosmo
- cyborg
- journal
- readable
- simplex
- slate
- spacelab
- spruce
- superhero
- united

NOTE: using any of those relies on access to the CDN. Those themese are
not copied to _static files.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
