### PR TITLE
Change code wrapping to only affect literal code blocks.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
@@ -105,8 +105,8 @@
     $('div.warning').addClass('alert');
 
     // Inline code styles to Bootstrap style.
-    $('tt.docutils').replaceWith(function () {
-      return $("<code />").text($(this).text());
-    });
+    $('tt.docutils span.pre:first-child').each(function (i, e) {
+        $(e).parent().replaceWith(function () {
+            return $("<code />").text($(this).text());});});
   });
 }($jqTheme || window.jQuery));


### PR DESCRIPTION
Hey,

I really like what you have done to get bootstrap working with sphinx, it's fantastic!

Because the same markup was being used for xrefs and inline code and inline code blocks don't link anywhere it's a bit of a confusing experience, some code block are links some are not. So i have instead created a basic patch that changes the wrapping of bootstrap code blocks to only effect the inline code blocks.  What are your thoughts?

EDIT: removed some unnecessary crap about literal blocks, since you obviously already style them.

Cheers,
Russell
