### PR TITLE
Literal markup

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
@@ -106,9 +106,9 @@
 
     // Inline code styles to Bootstrap style.
     $('tt.docutils.literal').not(".xref").each(function (i, e) {
-        // ignore references
-        if (!$(e).parent().hasClass("reference")) {
-            $(e).replaceWith(function () {
-                return $("<code />").text($(this).text());});}});
+      // ignore references
+      if (!$(e).parent().hasClass("reference")) {
+        $(e).replaceWith(function () {
+          return $("<code />").text($(this).text());});}});
   });
 }($jqTheme || window.jQuery));


### PR DESCRIPTION
Hey Ryan,

I have updated the js selector, I think this a better solution.  It targets all literal blocks then limits based on not an xref and not a reference link.  Unlike the last one any off site links won't be styled as code in this version.

I have tested it on your demo and it seems to look ok, feedback is welcome.

Cheers,
Russell
