### PR TITLE
Scroll the window when jumping to an anchor.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
@@ -52,6 +52,17 @@
   };
 
   $(document).ready(function () {
+
+    /*
+     * Scroll the window to avoid the topnav bar 
+     * https://github.com/twitter/bootstrap/issues/1768
+     */
+    if ($("#navbar.navbar-fixed-top").length > 0) {
+      var shiftWindow = function() { scrollBy(0, -50); };
+      if (location.hash) shiftWindow();
+      window.addEventListener("hashchange", shiftWindow);
+    }
+
     // Add styling, structure to TOC's.
     $(".dropdown-menu").each(function () {
       $(this).find("ul").each(function (index, item){


### PR DESCRIPTION
I have added a fix that i took from a bootstrap bug report.

It scrolls the page so that if you are using a fixed topnav, anchors will be visible when you link to them or click on them.

Cheers,
Russell
