### PR TITLE
Put <div class="container"> inside navbar

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -31,34 +31,36 @@
 {% macro navBar() %}
   <div id="navbar" class="{{ theme_navbar_class }} {% if theme_navbar_fixed_top == 'true' -%} navbar-fixed-top{%- endif -%}">
     <div class="navbar-inner">
-      <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
-      <button class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
+      <div class="container">
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
 
-      <a class="brand" href="{{ pathto(master_doc) }}">{% if theme_navbar_title -%}{{ theme_navbar_title|e }}{%- else -%}{{ project|e }}{%- endif -%}</a>
-      <span class="navbar-text pull-left"><b>{{ version|e }}</b></span>
+        <a class="brand" href="{{ pathto(master_doc) }}">{% if theme_navbar_title -%}{{ theme_navbar_title|e }}{%- else -%}{{ project|e }}{%- endif -%}</a>
+        <span class="navbar-text pull-left"><b>{{ version|e }}</b></span>
 
-      <div class="nav-collapse">
-        <ul class="nav">
-          <li class="divider-vertical"></li>
-          {% block sidebartoc %}
-            {% include "globaltoc.html" %}
-            {% include "localtoc.html" %}
+        <div class="nav-collapse">
+          <ul class="nav">
+            <li class="divider-vertical"></li>
+            {% block sidebartoc %}
+              {% include "globaltoc.html" %}
+              {% include "localtoc.html" %}
+            {% endblock %}
+            {% block sidebarrel %}
+              {% include "relations.html" %}
+            {% endblock %}
+            {% if theme_source_link_position == "nav" %}
+              <li>{% include "sourcelink.html" %}</li>
+            {% endif %}
+          </ul>
+
+          {% block sidebarsearch %}
+            {% include "searchbox.html" %}
           {% endblock %}
-          {% block sidebarrel %}
-            {% include "relations.html" %}
-          {% endblock %}
-          {% if theme_source_link_position == "nav" %}
-            <li>{% include "sourcelink.html" %}</li>
-          {% endif %}
-        </ul>
-
-        {% block sidebarsearch %}
-          {% include "searchbox.html" %}
-        {% endblock %}
+        </div>
       </div>
     </div>
   </div>
@@ -80,8 +82,8 @@
 {% block sidebarsourcelink %}{% endblock %}
 
 {%- block content %}
+{{ navBar() }}
 <div class="container">
-  {{ navBar() }}
   {% block body %}{% endblock %}
 </div>
 {%- endblock %}


### PR DESCRIPTION
The effect of this change is that the navigation bar doesn't stretch to the edge of the browser window but instead has the same left/right extent as the page body. Most bootstrap pages do things that way. (Btw, most of the diff is caused by extra indentation. WIth `git diff -b` it's just four lines.)
