### PR TITLE
Rephrase "Site" in globaltoc as "Contents"

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/globaltoc.html
+++ b/sphinx_bootstrap_theme/bootstrap/globaltoc.html
@@ -1,7 +1,7 @@
 <li class="dropdown globaltoc-container">
   <a href="{{ pathto(master_doc) }}"
      class="dropdown-toggle"
-     data-toggle="dropdown">{{ _('Site') }} <b class="caret"></b></a>
+     data-toggle="dropdown">{{ _('Contents') }} <b class="caret"></b></a>
   <ul class="dropdown-menu globaltoc"
     >{{ toctree(maxdepth=theme_globaltoc_depth|toint, collapse=False, includehidden=theme_globaltoc_includehidden|tobool) }}</ul>
 </li>


### PR DESCRIPTION
"Site" has no clear meaning in the context of package documentation--the docs could be part of a larger web page.
