### PR TITLE
Alternative solution to anchor titles being covered by the floating nav.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -35,6 +35,9 @@ body {
 }
 {% endif %}
 
+.section {
+  padding-top: 30px;
+}
 
 {%- block sidebarlogo %}
   {%- if logo %}

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js
@@ -53,21 +53,6 @@
 
   $(document).ready(function () {
 
-    /*
-     * Scroll the window to avoid the topnav bar
-     * https://github.com/twitter/bootstrap/issues/1768
-     */
-    if ($("#navbar.navbar-fixed-top").length > 0) {
-      var navHeight = $("#navbar").height(),
-        shiftWindow = function() { scrollBy(0, -navHeight - 10); };
-
-      if (location.hash) {
-        shiftWindow();
-      }
-
-      window.addEventListener("hashchange", shiftWindow);
-    }
-
     // Add styling, structure to TOC's.
     $(".dropdown-menu").each(function () {
       $(this).find("ul").each(function (index, item){


### PR DESCRIPTION
This is an alternative solution to the floating nav problem where the title of the section is covered by the navbar.

e.g. when clicking on something from the dropdown, the page scrolls, but the navbar covers the title of the section.

Pros,
I like it better because it's not using javascript hackory to make the title show so it's more reliable.

Cons,
The main draw back is that because it adds more empty space into the document if there isn't much content then it really stands out.
