### PR TITLE
network-path reference for bootswatch theme

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -13,7 +13,7 @@
 %}
 {% if theme_bootswatch_theme %}
 {% set css_files = css_files + [
-    'http://netdna.bootstrapcdn.com/bootswatch/2.3.2/' + theme_bootswatch_theme + '/bootstrap.min.css'
+    '//netdna.bootstrapcdn.com/bootswatch/2.3.2/' + theme_bootswatch_theme + '/bootstrap.min.css'
   ]
 %}
 {% endif %}


### PR DESCRIPTION
This is to fetch the bootswatch theme using the same scheme as the page and prevent the browser to block it as "unsafe content" when the doc is served over https (the cdn provides both http and https).
