### PR TITLE
Navbar truncation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
  History
 =========
 
+v0.2.7
+======
+
+* Truncate long page titles in navigation bar (`@aababilov`_)
+
 v0.2.6
 ======
 * Use network path for Bootswatch (`@nail`_)

--- a/sphinx_bootstrap_theme/bootstrap/relations.html
+++ b/sphinx_bootstrap_theme/bootstrap/relations.html
@@ -4,5 +4,5 @@
 {%- endif %}
 {%- if next %}
   <li><a href="{{ next.link|e }}"
-         title="{{ _('Next Chapter: ') + prev.title|striptags }}">{{ next.title|striptags|truncate(length=16, killwords=True) }} {{ "&raquo;"|safe }}</a></li>
+         title="{{ _('Next Chapter: ') + next.title|striptags }}">{{ next.title|striptags|truncate(length=16, killwords=True) }} {{ "&raquo;"|safe }}</a></li>
 {%- endif %}


### PR DESCRIPTION
Hey,

Here is a solution to #27 the long titles in the next, prev buttons in the navigation bar. I happened accross it by chance, it by @aababilov.
![screenshot from 2013-07-25 19 46 51](https://f.cloud.github.com/assets/2660/854831/aa9c7ac8-f50f-11e2-9992-76921298c759.png)

Cheers,
Russell
