### PR TITLE
Add a new {% navbarextra %} block

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -65,6 +65,8 @@
                 {% include "relations.html" %}
               {% endblock %}
             {% endif %}
+            {% block navbarextra %}
+            {% endblock %}
             {% if theme_source_link_position == "nav" %}
               <li>{% include "sourcelink.html" %}</li>
             {% endif %}


### PR DESCRIPTION
My use case for this block is to add an extra "Try it now" link for my library which can be run in the browser. I want it to appear at the end of the other navbar links, but before the search box.
