### PR TITLE
Code highlighting block - background color visible behind rounding

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -59,6 +59,10 @@ table {
     font-size: 12px;
 }
 
+div.highlight {
+  background: none;
+}
+
 table.field-list {
   width: auto;
 }


### PR DESCRIPTION
See the screnshots below:
DIV.highlight is defined in pygments.css, but Boostrap also defines background for PRE.

Ideally CSS selector should only affects div.highligh which have child < pre/>, but I don't know whether it's possible at all.
