### PR TITLE
Move the scroll handlers to the window load event

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -51,8 +51,7 @@
       .attr("border", 0);
   };
 
-  $(document).ready(function () {
-
+  $(window).load(function () {
     /*
      * Scroll the window to avoid the topnav bar
      * https://github.com/twitter/bootstrap/issues/1768
@@ -62,12 +61,14 @@
         shiftWindow = function() { scrollBy(0, -navHeight - 10); };
 
       if (location.hash) {
-        shiftWindow();
+        setTimeout(shiftWindow, 1);
       }
 
       window.addEventListener("hashchange", shiftWindow);
     }
+  });
 
+  $(document).ready(function () {
     // Add styling, structure to TOC's.
     $(".dropdown-menu").each(function () {
       $(this).find("ul").each(function (index, item){


### PR DESCRIPTION
This moves the logic for scrolling the window to account for the fixed
navbar to the window load function. When navigating to a hashtag link on
a different page, the browser sets the scroll position _after_ the
document read function runs, resulting in the header being obscured by
the navbar. This fix ensures that the js executes after the browser sets
the scroll position. Tested on Chrome 29.0.1547.76 and Firefox 17.0.4.
