### PR TITLE
Cannot provide bootswich css in local,

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -7,7 +7,7 @@
 
   {% if theme_bootswatch_theme %}
     {% set theme_css_files = theme_css_files + [
-        '//netdna.bootstrapcdn.com/bootswatch/' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css',
+        'http://netdna.bootstrapcdn.com/bootswatch/' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css',
         '_static/bootstrap-sphinx.css'
       ]
     %}


### PR DESCRIPTION
When view document generated by bootstrap-theme with firefox and chrome in local (direct file-systeme open), bootswich link is `file://netdna.bootstrapcdn.com~`, and miss css.

I think "bootswich" url link is not only "//", and need "http://".
