### PR TITLE
Style all admonitions, downgrade warning styling

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -149,8 +149,9 @@
     patchTables();
 
     // Add Note, Warning styles. (BS v2,3 compatible).
-    $('div.note').addClass('alert alert-info');
-    $('div.warning').addClass('alert alert-danger alert-error');
+    $('.admonition').addClass('alert alert-info')
+      .filter('.warning, .caution').removeClass('alert-info').addClass('alert-warning').end()
+      .filter('.error, .danger').removeClass('alert-info').addClass('alert-danger alter-error').end();
 
     // Inline code styles to Bootstrap style.
     $('tt.docutils.literal').not(".xref").each(function (i, e) {


### PR DESCRIPTION
Should fix #76 
- add a default "info" alert style to all docutils admonitions
- move "warning" to warning level, add "caution" synonym
- add "error" and "danger" admonitions with danger/error styles
