### PR TITLE
Change order of CSS files to allow overriding

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -37,7 +37,7 @@
 {% if not bootswatch_css_custom %}
   {% set bootswatch_css_custom = [] %}
 {% endif %}
-{% set css_files = css_files + theme_css_files + bootswatch_css_custom %}
+{% set css_files = theme_css_files + bootswatch_css_custom + css_files %}
 
 {% set script_files = script_files + [
     '_static/js/jquery-1.11.0.min.js',


### PR DESCRIPTION
In many of my projects, I override the `css_files` variable in s-b-s to slightly tweak the way things look. This usage was recently broken, it appears, by a change in the ordering of CSS files. Now the bootstrap CSS occurs after my user-defined one and overrides the changes I make. This PR fixes that.
