### PR TITLE
Don't always adjust the sidebar

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -89,8 +89,7 @@
     $(".bs-sidenav ul").addClass("nav nav-list");
     $(".bs-sidenav > ul > li > a").addClass("nav-header");
 
-    {% if theme_bootstrap_version == "3" %}
-    {% if theme_navbar_fixed_top %}
+    {% if theme_navbar_fixed_top and theme_bootstrap_version == "3" %}
     // back to top
     setTimeout(function () {
       var $sideBar = $('.bs-sidenav');
@@ -111,7 +110,6 @@
         }
       });
     }, 100);
-    {% endif %}
     {% endif %}
 
     // Local TOC.


### PR DESCRIPTION
When navbar_fixed_top is not set to true, there shouldn't be any Javascript updating it's position. 

Currently the sidebar always has this Javascript applied to it in Bootstrap 3, which makes the sidebar jump around even when 'navbar_fixed_top' is false. 

I don't often Python or write templates in Sphinx's format, so it might be better to be
`{% if (theme_navbar_fixed_top|tobool) %}`   
