### PR TITLE
Remove divider-vertical from navbar.html.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/navbar.html
+++ b/sphinx_bootstrap_theme/bootstrap/navbar.html
@@ -18,7 +18,6 @@
 
         <div class="collapse navbar-collapse nav-collapse">
           <ul class="nav navbar-nav">
-            <li class="divider-vertical"></li>
             {% if theme_navbar_links %}
               {%- for link in theme_navbar_links %}
                 <li><a href="{{ pathto(*link[1:]) }}">{{ link[0] }}</a></li>


### PR DESCRIPTION
.divider-vertical is not supported in Bootstrap 3. See https://github.com/twbs/bootstrap/issues/9501.
