### PR TITLE
Fix for Python 3

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -54,7 +54,7 @@ source_link_position = nav
 #
 # Options are nothing with "" (default) or the name of a valid theme such as
 # "amelia" or "cosmo".
-bootswatch_theme = ""
+bootswatch_theme = 
 
 # Switch Bootstrap version?
 # Values: "3" (default) or "2"


### PR DESCRIPTION
The ConfigParser on Python 3 reads a value of `""` as the string containing two double-quotes, not the empty string.  Therefore, by default on Python 3, the bootswatch theme name is set to `""` rather than the empty string, and of course the page has trouble rendering if that's the case.
