### PR TITLE
BUG: Fix py3 empty string parsing for `theme_bootswatch_theme`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
  History
 =========
 
+Current
+=======
+* Fix situation where Python 3 + modern Sphinx results in empty strings being
+  interpreted as a non-existent Bootswatch theme for
+  ``theme_bootswatch_theme`` by permissively allowing old (empty quotes) or
+  new (empty or ``None``) styles.
+  (`@EricFromCanada`_, `@peteut`_, `@mdboom`_)
+
 v0.4.3
 ======
 * Add ``fonts/`` directories to bootswatch. (`@gkthiruvathukal`_)
@@ -196,6 +204,7 @@ v0.0.1
 .. _@adamcharnock: https://github.com/adamcharnock
 .. _@cdbennett: https://github.com/cdbennett
 .. _@Danack: https://github.com/Danack
+.. _@EricFromCanada: https://github.com/EricFromCanada
 .. _@fjfeijoo: https://github.com/fjfeijoo
 .. _@gkthiruvathukal: https://github.com/gkthiruvathukal
 .. _@grncdr: https://github.com/grncdr
@@ -203,10 +212,12 @@ v0.0.1
 .. _@kaycebasques: https://github.com/kaycebasques
 .. _@kosiakk: https://github.com/kosiakk
 .. _@masklinn: https://github.com/masklinn
+.. _@mdboom: https://github.com/mdboom
 .. _@MiCHiLU: https://github.com/MiCHiLU
 .. _@nail: https://github.com/nail
 .. _@newgene: https://github.com/newgene
 .. _@oscarcp: https://github.com/oscarcp
+.. _@peteut: https://github.com/peteut
 .. _@russell: https://github.com/russell
 .. _@sccolbert: https://github.com/sccolbert
 .. _@shiumachi: https://github.com/shiumachi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Makefile: For Python3 development.
+# Because fabric doesn't work in Py3 :(
+
+.PHONY: clean demo demo_server
+
+clean:
+	rm -rf "dist" \
+		"build" \
+		"demo/build" \
+		"sphinx_bootstrap_theme.egg-info" \
+
+demo:
+	cd demo && make html
+
+demo_server:
+	cd demo/build/html && python -m http.server 8000

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ your "conf.py" file::
 
         # Bootswatch (http://bootswatch.com/) theme.
         #
-        # Options are nothing with "" (default) or the name of a valid theme
+        # Options are nothing (default) or the name of a valid theme
         # such as "amelia" or "cosmo".
         'bootswatch_theme': "united",
 
@@ -259,6 +259,15 @@ Then, view the site in the development server::
 
 Also, if you are adding a new type of styling or Sphinx or Bootstrap construct,
 please add a usage example to the "Examples" page.
+
+**Note**: If you are in Python 3, Fabric isn't available, so we have a very
+rough Makefile in its place. Try:
+
+    $ make clean && make demo
+
+Then, view the site in the development server::
+
+    $ make demo_server
 
 
 Licenses

--- a/TODO.rst
+++ b/TODO.rst
@@ -52,7 +52,10 @@ Notes
 
 Updating bootswatch:
 
+.. code-block:: bash
+
     $ cd scm/vendor/bootswatch
     $ find . -name "bootstrap.min.css" | \
       egrep -v "\/2|bower_components\/" | \
       xargs tar cf - > ~/Desktop/bootswatch-3.2.0.tar
+    # TODO: AND... add the fonts too!

--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -139,7 +139,7 @@ html_theme_options = {
 
     # Bootswatch (http://bootswatch.com/) theme.
     #
-    # Options are nothing with "" (default) or the name of a valid theme such
+    # Options are nothing (default) or the name of a valid theme such
     # as "amelia" or "cosmo".
     #
     # Themes:

--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -9,7 +9,7 @@
   {% set bs_span_prefix = "span" %}
 {% endif %}
 
-{% if theme_bootswatch_theme %}
+{% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}
   {# BS2 needs "bootstrap-responsive.css". BS3 doesn't. #}
   {% if theme_bootstrap_version == "3" %}
     {% set theme_css_files = theme_css_files + [

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -18,14 +18,14 @@
 {% endif %}
   {% if theme_navbar_fixed_top|tobool %}
   body {
-  {% if theme_bootswatch_theme %}
+  {% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}
     padding-top: 60px;
   {% else %}
     padding-top: 40px;
   {% endif %}
   }
   .page-top {
-  {% if theme_bootswatch_theme %}
+  {% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}
     top: 60px;
   {% else %}
     top: 40px;

--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -52,9 +52,9 @@ source_link_position = nav
 
 # Bootswatch (http://bootswatch.com/) theme.
 #
-# Options are nothing with "" (default) or the name of a valid theme such as
+# Options are nothing (default) or the name of a valid theme such as
 # "amelia" or "cosmo".
-bootswatch_theme = ""
+bootswatch_theme =
 
 # Switch Bootstrap version?
 # Values: "3" (default) or "2"


### PR DESCRIPTION
Fixes: https://github.com/ryan-roemer/sphinx-bootstrap-theme/issues/115

Closes: https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/116

/cc @EricFromCanada @peteut @mdboom
