### PR TITLE
Prevents sidenav jumps when scrolling down.

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -181,7 +181,7 @@ table.field-list {
   }
   .bs-sidenav.affix {
     position: fixed; /* Undo the static from mobile first approach */
-    top: 80px;
+    top: 60px;
   }
   .bs-sidenav.affix-bottom {
     position: absolute; /* Undo the static from mobile first approach */

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -98,7 +98,7 @@
         offset: {
           top: function () {
             var offsetTop      = $sideBar.offset().top;
-            var sideBarMargin  = parseInt($sideBar.children(0).css('margin-top'), 10);
+            var sideBarMargin  = parseInt($sideBar.children(0).css('margin-top'), 50);
             var navOuterHeight = $('#navbar').height();
 
             return (this.top = offsetTop - navOuterHeight - sideBarMargin);


### PR DESCRIPTION
The sidebar table of contents jumped down 10-20 pixels when scrolling down from the top. I played with these numbers until it seemed to work. This was especially visible when I used it with html5shiv.

Don't know if anybody else have seen this, but I've tested it on Chrome on Linux and Chrome+IE9 on Windows. This fixes that, but don't ask me _why_ these numbers work.
