### PR TITLE
Wrap navbar img in span

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/navbar.html
+++ b/sphinx_bootstrap_theme/bootstrap/navbar.html
@@ -9,7 +9,7 @@
         </button>
         <a class="navbar-brand" href="{{ pathto(master_doc) }}">
           {%- block sidebarlogo %}
-            {%- if logo %}<img src="{{ pathto('_static/' + logo, 1) }}">{%- endif %}
+            {%- if logo %}<span><img src="{{ pathto('_static/' + logo, 1) }}"></span>{%- endif %}
           {%- endblock %}
           {% if theme_navbar_title -%}{{ theme_navbar_title|e }}{%- else -%}{{ project|e }}{%- endif -%}
         </a>


### PR DESCRIPTION
Without the `span` element, the brand title is forced to a newline, breaking the theme look.