### PR TITLE
jQuery#minHeight isn't function

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -97,7 +97,7 @@
 
       // Enlarge content if sidebar is larger.
       if ($sideBar.outerHeight(true) > $content.outerHeight(true)) {
-        $content.minHeight($sideBar.outerHeight(true));
+        $content.css("min-height", $sideBar.outerHeight(true));
       }
 
       $sideBar


### PR DESCRIPTION
When content is shorter than sidebar, set min-height style on content via `jQuery#minHeight`.
But, It isn't defined in pure jQuery.

![image](https://cloud.githubusercontent.com/assets/191358/25987968/257466a4-3731-11e7-8a92-351e98546741.png)

cf. c8adf99c37d2dc277921cae93d16ac0faf4635ca 

Fixes #161