### PR TITLE
Switch to css imports rather than css_files hackery.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@
 
 Unreleased
 ==========
-* Fix `css_files` breakage from Sphinx `1.6+` update.
+* Fix ``css_files`` breakage from Sphinx `1.6+` update.
   `#158 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/158>`_,
   `#160 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/160>`_.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
  History
 =========
 
+Unreleased
+==========
+* Fix `css_files` breakage from Sphinx `1.6+` update.
+  `#158 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/158>`_,
+  `#160 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/160>`_.
+
+* **Breaking Change**: Remove ``bootswatch_css_custom`` override, and instead opt for documenting idiomatic Sphinx-version specific generic overrides for custom CSS.
+
 v0.4.14
 =======
 * Fix visibiliy of multiple footnote references. (`@drewhutchison`_)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@
 
 Unreleased
 ==========
-* Fix ``css_files`` breakage from Sphinx `1.6+` update.
+* Fix ``css_files`` breakage from Sphinx ``1.6+`` update.
   `#158 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/158>`_,
   `#160 <https://github.com/ryan-roemer/sphinx-bootstrap-theme/pull/160>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ configured as above, but with the following code::
     {% extends "!layout.html" %}
 
     {# Custom CSS overrides #}
-    {% set bootswatch_css_custom = ['_static/my-styles.css'] %}
+    {% set bootswatch_css_custom = ['my-styles.css'] %}
 
 Then, in the new file "source/_static/my-styles.css", add any appropriate
 styling, e.g. a bold background color::

--- a/README.rst
+++ b/README.rst
@@ -204,26 +204,39 @@ file to override a style, which in the demo would be something like::
     $ mkdir source/_static
     $ touch source/_static/my-styles.css
 
+In the new file "source/_static/my-styles.css", add any appropriate styling,
+e.g. a bold background color::
+
+    footer {
+      background-color: red;
+    }
+
 Then, in "conf.py", edit this line::
 
     html_static_path = ["_static"]
 
-You will also need the override template "source/_templates/layout.html" file
+From there it depends on which version of Sphinx you are using:
+
+**Sphinx <= 1.5**
+
+You will need the override template "source/_templates/layout.html" file
 configured as above, but with the following code::
 
     {# Import the theme's layout. #}
     {% extends "!layout.html" %}
 
     {# Custom CSS overrides #}
-    {% set bootswatch_css_custom = ['my-styles.css'] %}
+    {% set css_files = css_files + ['_static/my-styles.css'] %}
 
-Then, in the new file "source/_static/my-styles.css", add any appropriate
-styling, e.g. a bold background color::
+**Sphinx >= 1.6**
 
-    footer {
-      background-color: red;
-    }
+Add a `setup` function in "conf.py" with stylesheet paths added relative to the
+static path::
 
+    def setup(app):
+        app.add_stylesheet("my-styles.css") # also can be a full URL
+        # app.add_stylesheet("ANOTHER.css")
+        # app.add_stylesheet("AND_ANOTHER.css")
 
 Theme Notes
 ===========

--- a/demo/source/_templates/layout.html
+++ b/demo/source/_templates/layout.html
@@ -1,8 +1,5 @@
 {% extends "!layout.html" %}
 
-{# Custom CSS overrides #}
-{# set bootswatch_css_custom = ['_static/my-styles.css'] #}
-
 {# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
 {% block header %}
   {{ super() }}
@@ -20,5 +17,3 @@
     });
   </script>
 {% endblock %}
-
-

--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -225,6 +225,9 @@ html_sidebars = {'sidebar': ['localtoc.html', 'sourcelink.html', 'searchbox.html
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'MyProjectDoc'
 
+# # Custom style overrides
+# def setup(app):
+#     app.add_stylesheet('my-styles.css')  # may also be an URL
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Fabric==1.6.0
-Sphinx==1.2.1
+Sphinx==1.6.1

--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -1,43 +1,12 @@
 {% extends "basic/layout.html" %}
 
-{% set theme_css_files = [] %}
 {% if theme_bootstrap_version == "3" %}
-  {% set bootstrap_version, bootstrap_additional_css, navbar_version = "3.3.6", "theme", "" %}
+  {% set bootstrap_version, navbar_version = "3.3.6", "" %}
   {% set bs_span_prefix = "col-md-" %}
 {% else %}
-  {% set bootstrap_version, bootstrap_additional_css, navbar_version = "2.3.2", "responsive", "-2" %}
+  {% set bootstrap_version, navbar_version = "2.3.2", "-2" %}
   {% set bs_span_prefix = "span" %}
 {% endif %}
-
-{% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}
-  {# BS2 needs "bootstrap-responsive.css". BS3 doesn't. #}
-  {% if theme_bootstrap_version == "3" %}
-    {% set theme_css_files = theme_css_files + [
-        '_static/bootswatch-' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css',
-        '_static/bootstrap-sphinx.css'
-      ]
-    %}
-  {% else %}
-    {% set theme_css_files = theme_css_files + [
-        '_static/bootswatch-' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css',
-        '_static/bootstrap-' + bootstrap_version + '/css/bootstrap-' + bootstrap_additional_css + '.min.css',
-        '_static/bootstrap-sphinx.css'
-      ]
-    %}
-  {% endif %}
-{% else %}
-  {% set theme_css_files = theme_css_files + [
-      '_static/bootstrap-' + bootstrap_version + '/css/bootstrap.min.css',
-      '_static/bootstrap-' + bootstrap_version + '/css/bootstrap-' + bootstrap_additional_css + '.min.css',
-      '_static/bootstrap-sphinx.css'
-    ]
-  %}
-{% endif %}
-
-{% if not bootswatch_css_custom %}
-  {% set bootswatch_css_custom = [] %}
-{% endif %}
-{% set css_files = css_files + theme_css_files + bootswatch_css_custom %}
 
 {% set script_files = script_files + [
     '_static/js/jquery-1.11.0.min.js',

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -30,12 +30,6 @@
     @import url("{{ 'bootstrap-' + bootstrap_version + '/css/bootstrap-' + bootstrap_additional_css + '.min.css' }}");
 {% endif %}
 
-{% if bootswatch_css_custom %}
-  {%- for css_custom in bootswatch_css_custom %}
-    @import url("{{ css_custom }}");
-  {%- endfor %}
-{% endif %}
-
 /*
  * Styles
  */

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -13,10 +13,8 @@
 
 {% if theme_bootstrap_version == "3" %}
   {% set bootstrap_version, bootstrap_additional_css = "3.3.6", "theme" %}
-  {% set bs_span_prefix = "col-md-" %}
 {% else %}
   {% set bootstrap_version, bootstrap_additional_css = "2.3.2", "responsive" %}
-  {% set bs_span_prefix = "span" %}
 {% endif %}
 
 {% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -5,6 +5,43 @@
  * Sphinx stylesheet -- Bootstrap theme.
  */
 
+/*
+ * Imports to aggregate everything together.
+ */
+
+@import url("basic.css");
+
+{% if theme_bootstrap_version == "3" %}
+  {% set bootstrap_version, bootstrap_additional_css = "3.3.6", "theme" %}
+  {% set bs_span_prefix = "col-md-" %}
+{% else %}
+  {% set bootstrap_version, bootstrap_additional_css = "2.3.2", "responsive" %}
+  {% set bs_span_prefix = "span" %}
+{% endif %}
+
+{% if theme_bootswatch_theme and theme_bootswatch_theme != "\"\"" %}
+  {# BS2 needs "bootstrap-responsive.css". BS3 doesn't. #}
+  {% if theme_bootstrap_version == "3" %}
+    @import url("{{ 'bootswatch-' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css' }}");
+  {% else %}
+    @import url("{{ 'bootswatch-' + bootstrap_version + '/' + theme_bootswatch_theme + '/bootstrap.min.css' }}");
+    @import url("{{ 'bootstrap-' + bootstrap_version + '/css/bootstrap-' + bootstrap_additional_css + '.min.css' }}");
+  {% endif %}
+{% else %}
+    @import url("{{ 'bootstrap-' + bootstrap_version + '/css/bootstrap.min.css' }}");
+    @import url("{{ 'bootstrap-' + bootstrap_version + '/css/bootstrap-' + bootstrap_additional_css + '.min.css' }}");
+{% endif %}
+
+{% if bootswatch_css_custom %}
+  {%- for css_custom in bootswatch_css_custom %}
+    @import url("{{ css_custom }}");
+  {%- endfor %}
+{% endif %}
+
+/*
+ * Styles
+ */
+
 .navbar-inverse .brand {
   color: #FFF;
 }

--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -1,7 +1,7 @@
 # Bootstrap Theme
 [theme]
 inherit = basic
-stylesheet = basic.css
+stylesheet = bootstrap-sphinx.css
 pygments_style = tango
 
 # Configurable options.


### PR DESCRIPTION
The theme uses `css_files` hackery, but that is deprecated in modern Sphinx and error prone because there are real object instances and not strings that now comprise `css_files`. See, e.g. #158 

This PR switches all of the conditionally-included CSS files into css `@import url("NAME.css");` statements and just now has _one_ root style sheet included the old fashioned way. Hopefully this is both backwards compatible with any previous Sphinx versions and works better as `css_files` goes off into deprecation sunset.

Would appreciate folks pulling this down and kicking the tires!

/cc @alexhagen @has2k1 @pcav