### PR TITLE
css fix of headerlink margin

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -117,6 +117,10 @@ div.highlight {
   background: none;
 }
 
+a.headerlink {
+  margin-left: 0.25em;
+}
+
 a.footnote-reference {
   vertical-align: super;
   font-size: 75%;


### PR DESCRIPTION
I've come across a small glitch in the layout of the headerlink. It's quite cramped to the header. I propose to give it a bit of margin.

before:
![grafik](https://user-images.githubusercontent.com/2836374/34702257-0b46d2e2-f4ed-11e7-9575-765e940a4dbb.png)

after:

![grafik](https://user-images.githubusercontent.com/2836374/34702276-2727bba2-f4ed-11e7-8d7f-239e46cd879a.png)
