### PR TITLE
fix sidebars showing up when not requested

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -3,6 +3,10 @@
 inherit = basic
 stylesheet = bootstrap-sphinx.css
 pygments_style = tango
+# The sphinx bootstrap theme includes information typically presented in a
+# theme's sidebar in the navbar, so these are disabled by default.
+# Users can override this with `html_sidebars` in their conf.py.
+sidebars =
 
 # Configurable options.
 [options]


### PR DESCRIPTION
Fixes #179.

@ryan-roemer check this out locally and build, you will see no sidebars on the main page (how it used to be).  If you comment out this change and rebuild the demo, you will see the sidebars leak in.

**Edit**: P.S. though it's a one line fix, a new release might be in order.  This likely broke many sites, regardless of if they new about it.  It broke my [bootstrap testing site](http://my-favorite-documentation-test.readthedocs.io/en/bootstrap/) for my own extension too x0