### PR TITLE
Fixing sidebar list HTML structure

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -34,9 +34,11 @@
       {%- if render_sidebar %}
       <div class="{{ bs_span_prefix }}3">
         <div id="sidebar" class="bs-sidenav" role="complementary">
-          {%- for sidebartemplate in sidebars %}
-            {%- include sidebartemplate %}
-          {%- endfor %}
+            <ul>
+              {%- for sidebartemplate in sidebars %}
+                {%- include sidebartemplate %}
+              {%- endfor %}
+            </ul>
         </div>
       </div>
       {%- endif %}

--- a/sphinx_bootstrap_theme/bootstrap/searchbox.html
+++ b/sphinx_bootstrap_theme/bootstrap/searchbox.html
@@ -1,9 +1,11 @@
 {%- if pagename != "search" %}
-<form action="{{ pathto('search') }}" method="get">
- <div class="form-group">
-  <input type="text" name="q" class="form-control" placeholder="Search" />
- </div>
-  <input type="hidden" name="check_keywords" value="yes" />
-  <input type="hidden" name="area" value="default" />
-</form>
+<li>
+    <form action="{{ pathto('search') }}" method="get">
+     <div class="form-group">
+      <input type="text" name="q" class="form-control" placeholder="Search" />
+     </div>
+      <input type="hidden" name="check_keywords" value="yes" />
+      <input type="hidden" name="area" value="default" />
+    </form>
+</li>
 {%- endif %}


### PR DESCRIPTION
The sidebar was missing a `<ul>` element causing list items to render off to the side. The search box also needed to be wrapped in an `<li>` after this change for semantic consistency.