### PR TITLE
FIX: Update javascript paths

### DIFF
--- a/sphinx_bootstrap_theme/__init__.py
+++ b/sphinx_bootstrap_theme/__init__.py
@@ -6,10 +6,23 @@ VERSION = (0, 6, 5)
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__
 
+
 def get_html_theme_path():
     """Return list of HTML theme paths."""
     theme_path = os.path.abspath(os.path.dirname(__file__))
     return [theme_path]
+
+
+def add_js(app):
+    bootstrap_version = \
+        app.builder.config.html_theme_options.get('bootstrap_version', '3')
+    add_js_file = getattr(app, 'add_js_file', app.add_javascript)
+    add_js_file('searchtools.js')
+    add_js_file('js/jquery-1.11.0.min.js')
+    add_js_file('js/jquery-fix.js')
+    add_js_file('bootstrap-%s/js/bootstrap.min.js' % (bootstrap_version,))
+    add_js_file('bootstrap-%s/js/bootstrap-sphinx.js' % (bootstrap_version,))
+
 
 def setup(app):
     """Setup."""
@@ -17,3 +30,4 @@ def setup(app):
     if hasattr(app, 'add_html_theme'):
         theme_path = get_html_theme_path()[0]
         app.add_html_theme('bootstrap', os.path.join(theme_path, 'bootstrap'))
+    app.connect('builder-inited', add_js)

--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -8,14 +8,6 @@
   {% set bs_span_prefix = "span" %}
 {% endif %}
 
-{% set script_files = script_files + [
-    '_static/js/jquery-1.11.0.min.js',
-    '_static/js/jquery-fix.js',
-    '_static/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js',
-    '_static/bootstrap-sphinx.js'
-  ]
-%}
-
 {%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
 
 {%- set bs_content_width = render_sidebar and "9" or "12"%}

--- a/sphinx_bootstrap_theme/bootstrap/search.html
+++ b/sphinx_bootstrap_theme/bootstrap/search.html
@@ -9,7 +9,6 @@
 #}
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
-{% set script_files = script_files + ['_static/searchtools.js'] %}
 {% block extrahead %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
@@ -42,7 +41,7 @@
     </div>
     <input type="submit" class="btn btn-default" value="{{ _('search') }}" />
     <span id="search-progress" style="padding-left: 10px"></span>
-  </form>  
+  </form>
   {% else %}
   <form class="form-search">
     <input type="text" class="input-medium search-query" name="q" value="" />
@@ -50,7 +49,7 @@
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>
   {% endif %}
-  
+
   {% if search_performed %}
     <h2>{{ _('Search Results') }}</h2>
     {% if not search_results %}


### PR DESCRIPTION
In sphinx 2.0.0.dev I get the following warning:
```
/home/larsoner/python/sphinx/sphinx/builders/html.py:144: RemovedInSphinx30Warning: builder.script_files is deprecated. Please use app.add_js_file() instead.                       
```
Here I try to use newer `add_js_file` if it's available. It looks like the fallback `add_javascript` has been around since 0.5, though, so that should be safe.

One drawback is that people who don't have `sphinx_bootstrap_theme` in 'extensions' but rather just do this manually:
```
html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
```
will no longer have working JS. So maybe a `README` update is in order to remind people they should just have it in their extension list for proper setup?