### PR TITLE
MAINT: Updates for latest sphinx

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/layout.html
+++ b/sphinx_bootstrap_theme/bootstrap/layout.html
@@ -8,14 +8,6 @@
   {% set bs_span_prefix = "span" %}
 {% endif %}
 
-{% set script_files = script_files + [
-    '_static/js/jquery-1.11.0.min.js',
-    '_static/js/jquery-fix.js',
-    '_static/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js',
-    '_static/bootstrap-sphinx.js'
-  ]
-%}
-
 {%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
 
 {%- set bs_content_width = render_sidebar and "9" or "12"%}
@@ -60,6 +52,10 @@
 <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
 <meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-1.11.0.min.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-fix.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/_static/bootstrap-sphinx.js', 1) }} "></script>
 {% endblock %}
 
 {# Silence the sidebar's, relbar's #}
@@ -73,7 +69,7 @@
 <div class="container">
   <div class="row">
     {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}
-    <div class="{{ bs_span_prefix }}{{ bs_content_width }} content">
+    <div class="body {{ bs_span_prefix }}{{ bs_content_width }} content" role="main">
       {% block body %}{% endblock %}
     </div>
     {% block sidebar2 %} {# possible location for sidebar #} {% endblock %}

--- a/sphinx_bootstrap_theme/bootstrap/search.html
+++ b/sphinx_bootstrap_theme/bootstrap/search.html
@@ -9,8 +9,8 @@
 #}
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
-{% set script_files = script_files + ['_static/searchtools.js'] %}
 {% block extrahead %}
+  <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }} "></script>
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>
@@ -42,7 +42,7 @@
     </div>
     <input type="submit" class="btn btn-default" value="{{ _('search') }}" />
     <span id="search-progress" style="padding-left: 10px"></span>
-  </form>  
+  </form>
   {% else %}
   <form class="form-search">
     <input type="text" class="input-medium search-query" name="q" value="" />
@@ -50,7 +50,7 @@
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>
   {% endif %}
-  
+
   {% if search_performed %}
     <h2>{{ _('Search Results') }}</h2>
     {% if not search_results %}


### PR DESCRIPTION
Sphinx has updated table styling a bit (https://github.com/sphinx-doc/sphinx/issues/6170) and it exposed a bug where it expects the main content to be [styled as `body`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/basic/layout.html#L172-L193) but it wasn't by `sphinx-bootstrap-theme`. Also Sphinx `script_files += ` support is deprecated. So this PR:

1. Adds `body` style to the main div.
2. Changes `script_files` to just use `<link rel="stylesheet" ` syntax instead.

Fixes our builds, which on latest `sphinx` looked wrong with tables rendered like:

![Screenshot from 2019-03-11 16-57-44](https://user-images.githubusercontent.com/2365790/54157537-df71de00-441e-11e9-9764-7d711500d944.png)

And with this PR the `script` warning is gone and renders like (if I add a `.body { min-width: unset !important; max-width: unset !important; }` to our custom CSS:

<img width="1373" alt="Screen Shot 2019-03-19 at 15 21 55" src="https://user-images.githubusercontent.com/2365790/54580113-c1c5f980-4a5a-11e9-80ae-867786836117.png">

But I am no Sphinx / HTML / js expert, so let me know if this isn't the right approach! I wasn't entirely sure how to validate that everything is working properly and nothing broke, so it would be good to have another set of eyes on the output, too, so we don't break people's pipelines.