### PR TITLE
Allow using Bootstrap3 panels instead of alerts for admonitions

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -59,10 +59,17 @@
 
 {% if theme_admonition_use_panel|tobool %}
 
-.panel-body {
+p.admonition-title {
+  margin: 0px;
+}
+
+div.admonition {
   padding: 0px;
-  padding-right: 15px;
-  padding-left: 15px;
+}
+
+.panel-body {
+  padding-top: 10px;
+  padding-bottom: 5px;
 }
 
 .panel-heading {

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -57,6 +57,20 @@
   height: 100%;
 }
 
+{% if theme_admonition_use_panel|tobool %}
+
+.panel-body {
+  padding: 0px;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.panel-heading {
+  font-weight: bold;
+}
+
+{% endif %}
+
 .page-top {
   top: 0px;
 }

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -153,11 +153,9 @@
     // Add Note, Warning styles. (BS v2,3 compatible).
     {% if theme_admonition_use_panel|tobool and theme_bootstrap_version == "3" %}
     $(".admonition-title")
-        .removeClass("admonition-title")
         .addClass("panel-heading").end();
     $(".admonition")
       .addClass("panel panel-info")
-      .removeClass("admonition")
       .filter(".warning, .caution")
         .removeClass("panel-info")
         .addClass("panel-warning").end()

--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.js_t
@@ -151,13 +151,35 @@
     patchTables();
 
     // Add Note, Warning styles. (BS v2,3 compatible).
-    $(".admonition").addClass("alert alert-info")
+    {% if theme_admonition_use_panel|tobool and theme_bootstrap_version == "3" %}
+    $(".admonition-title")
+        .removeClass("admonition-title")
+        .addClass("panel-heading").end();
+    $(".admonition")
+      .addClass("panel panel-info")
+      .removeClass("admonition")
+      .filter(".warning, .caution")
+        .removeClass("panel-info")
+        .addClass("panel-warning").end()
+      .filter(".error, .danger")
+        .removeClass("panel-info")
+        .addClass("panel-danger").end()
+      .each(function() {
+        $(this)
+          .children()
+            .not(".panel-heading")
+            .wrapAll("<div class='panel-body'></div>").end();
+      });
+    {% else %}
+    $(".admonition")
+      .addClass("alert alert-info")
       .filter(".warning, .caution")
         .removeClass("alert-info")
         .addClass("alert-warning").end()
       .filter(".error, .danger")
         .removeClass("alert-info")
         .addClass("alert-danger alert-error").end();
+    {% endif %}
 
     // Inline code styles to Bootstrap style.
     $("tt.docutils.literal").not(".xref").each(function (i, e) {

--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -65,4 +65,4 @@ bootswatch_theme =
 bootstrap_version = 3
 
 # Use Bootstrap panels instead of alerts for admonitions
-admonition_use_panel = true
+admonition_use_panel = false

--- a/sphinx_bootstrap_theme/bootstrap/theme.conf
+++ b/sphinx_bootstrap_theme/bootstrap/theme.conf
@@ -63,3 +63,6 @@ bootswatch_theme =
 # Switch Bootstrap version?
 # Values: "3" (default) or "2"
 bootstrap_version = 3
+
+# Use Bootstrap panels instead of alerts for admonitions
+admonition_use_panel = true


### PR DESCRIPTION
Hi there!

I've been using your Sphinx theme ever since `sphinxjp.themes.basicstrap` started breaking, and I've never regretted it, it now powers [https://instalooter.readthedocs.io/en/latest/](https://instalooter.readthedocs.io/en/latest/) and I'm very happy with the result.

I tend to use a lot of admonitions in my docstrings (mostly because Napoleon with Google docstrings make them feel quite natural), but one thing I never really liked was that the rendered alerts were making any special text hard to read (for instance with the `flatly` theme):

![1](https://user-images.githubusercontent.com/8660647/65879724-bd2ab800-e390-11e9-9414-d9d5872a5cc3.png)

However, using panels instead of alerts really helps with legibility while still feeling like a coherent section:

![2](https://user-images.githubusercontent.com/8660647/65879768-d7649600-e390-11e9-94d7-9e9d5c063b61.png)

I added the `admonition_use_panel` option to the theme configuration that must be manually set to `True` to enable the new behaviour (therefore this change is backwards compatible). I also reduced the padding a bit from the default to give the panels a more compact look, so that they take around the same space as the original alerts (title aside).




