### PR TITLE
Modern CI and Python Tooling

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,69 @@
+name: Tests
+on: [push]
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - name: Install Tox
+        run: pip install tox
+      - name: Lint
+        run: tox -e flake8
+  dist:
+    name: Distribution Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - name: Install Tox
+        run: pip install tox
+      - name: Distribution Check
+        run: tox -e dist
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+      - name: Install Tox
+        run: pip install tox
+      - name: Build Docs
+        run: tox -e docs
+  test:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+    name: Py ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Tox
+        run: pip install tox
+      - name: Test Sphinx 1.8.5
+        env:
+          SPHINX_VERSION: ==1.8.5
+        run: tox -e py
+      - name: Test Sphinx 2.0
+        env:
+          SPHINX_VERSION: ==2.0
+        run: tox -e py
+        if: matrix.python-version >= 3.5
+      - name: Test Sphinx Latest
+        run: tox -e py
+        if: matrix.python-version >= 3.5

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,138 @@ __pycache__
 .vscode
 Pipfile*
 
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+

--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -16,8 +16,15 @@ import sphinx_bootstrap_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-# Disabled: , 'sphinx.ext.intersphinx'
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.todo',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode'
+]
+
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -302,7 +309,3 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}

--- a/demo/source/downloads.rst
+++ b/demo/source/downloads.rst
@@ -1,9 +1,0 @@
-===========
- Downloads
-===========
-
-The following zip bundles can be directly installed into your themes directory.
-See the :doc:`README` page for zip bundle installation instructions.
-
-Versions
-========

--- a/demo/source/examples.rst
+++ b/demo/source/examples.rst
@@ -195,12 +195,12 @@ An example Python function.
    :param value: exception value
    :param tb: traceback object
    :param limit: maximum number of stack frames to show
-   :type limit: integer or None
-   :rtype: list of strings
+   :type limit: int or None
+   :rtype: list[str]
 
-An example JavaScript function.
+An example C++ function.
 
-.. js:class:: MyAnimal(name[, age])
+.. cpp:function:: int foo(bool use_random = false)
 
-   :param string name: The name of the animal
-   :param number age: an optional age for the animal
+   :param use_random: Whether or not to return a random number.
+   :return: ``42`` if ``use_random == false``, a random number otherwise.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,38 @@
+[metadata]
+name = sphinx-bootstrap-theme
+version = attr: sphinx_bootstrap_theme.__version__
+author = Ryan Roemer
+author-email = ryan@loose-bits.com
+home-page = http://ryan-roemer.github.com/sphinx-bootstrap-theme/README.html
+description = Sphinx Bootstrap Theme.
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+keywords = sphinx, bootstrap, html, theme
+classifiers =
+  Development Status :: 5 - Production/Stable
+  Environment :: Web Environment
+  Intended Audience :: Developers
+  Intended Audience :: System Administrators
+  License :: OSI Approved :: MIT License
+  Operating System :: OS Independent
+  Programming Language :: Python
+  Programming Language :: Python :: 2
+  Programming Language :: Python :: 3
+  Topic :: Internet
+  Topic :: Software Development :: Documentation
+
+[bdist_wheel]
+universal = 1
+
+[options]
+zip_safe = false
+include_package_data = true
+packages =
+  sphinx_bootstrap_theme
+  sphinx_bootstrap_theme.bootstrap
+setup_requires =
+  setuptools
+
+[options.entry_points]
+sphinx.html_themes =
+  bootstrap = sphinx_bootstrap_theme

--- a/setup.py
+++ b/setup.py
@@ -1,72 +1,9 @@
 """Sphinx Bootstrap Theme package."""
 import os
-from setuptools import setup, find_packages
+import setuptools
 
-from sphinx_bootstrap_theme import __version__
-
-###############################################################################
-# Environment and Packages.
-###############################################################################
 # Don't copy Mac OS X resource forks on tar/gzip.
 os.environ['COPYFILE_DISABLE'] = "true"
 
-# Packages.
-MOD_NAME = "sphinx_bootstrap_theme"
-PKGS = [x for x in find_packages() if x.split('.')[0] == MOD_NAME]
-
-
-###############################################################################
-# Helpers.
-###############################################################################
-def read_file(name):
-    """Read file name (without extension) to string."""
-    cur_path = os.path.dirname(__file__)
-    exts = ('txt', 'rst')
-    for ext in exts:
-        path = os.path.join(cur_path, '.'.join((name, ext)))
-        if os.path.exists(path):
-            with open(path, 'rt') as file_obj:
-                return file_obj.read()
-
-    return ''
-
-
-###############################################################################
-# Setup.
-###############################################################################
-setup(
-    name="sphinx-bootstrap-theme",
-    version=__version__,
-    use_2to3=True,
-    description="Sphinx Bootstrap Theme.",
-    long_description=read_file("README"),
-    url="http://ryan-roemer.github.com/sphinx-bootstrap-theme/README.html",
-
-    author="Ryan Roemer",
-    author_email="ryan@loose-bits.com",
-
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Web Environment",
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 3",
-        "Topic :: Internet",
-        "Topic :: Software Development :: Documentation",
-    ],
-
-    install_requires=[
-        "setuptools",
-    ],
-    entry_points = {
-        'sphinx.html_themes': [
-            'bootstrap = sphinx_bootstrap_theme',
-        ]
-    },
-    packages=PKGS,
-    include_package_data=True,
-)
+# Setup the package.
+setuptools.setup()

--- a/sphinx_bootstrap_theme/__init__.py
+++ b/sphinx_bootstrap_theme/__init__.py
@@ -6,10 +6,12 @@ VERSION = (0, 8, 0)
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__
 
+
 def get_html_theme_path():
     """Return list of HTML theme paths."""
     theme_path = os.path.abspath(os.path.dirname(__file__))
     return [theme_path]
+
 
 def setup(app):
     """Setup."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,67 @@
+[tox]
+# By default, run tests and linting checks when invoking `tox`.
+envlist = py, flake8
+
+[testenv]
+passenv = PYTHONWARNINGS
+deps =
+    # NOTE: SPHINX_VERSION environment variable must have `==`, e.g.:
+    #       SPHINX_VERSION="==1.8.5" tox
+    #       On Unix, the double quotes are not necessary provided no spaces.
+    sphinx{env:SPHINX_VERSION:}
+commands =
+    # TODO: create / add unit tests with pytest.
+    sphinx-build --version
+
+# Build demo site in nitpicky / warnings=error mode.
+[testenv:docs]
+changedir = demo
+commands =
+    sphinx-build -W -n -b html -d {envtmpdir}/doctrees source {envtmpdir}/html
+
+# Open a development server.  See options here:
+# https://github.com/GaretJax/sphinx-autobuild
+#
+# Example run on port other than 8000:
+# tox -e server -- -p 8080
+[testenv:server]
+usedevelop = true
+recreate = true
+deps =
+    {[testenv]deps}
+    sphinx-autobuild
+commands =
+    sphinx-autobuild -a -E \
+                     -b html \
+                     -d {envtmpdir}/doctrees \
+                     --watch {toxinidir}/sphinx_bootstrap_theme \
+                     {posargs} \
+                     {toxinidir}/demo/source \
+                     {envtmpdir}/html
+
+# Linting checks.
+[testenv:flake8]
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 {posargs} setup.py sphinx_bootstrap_theme
+
+# Package for uploading to PyPI.  Everything is put in dist/ folder.
+[testenv:dist]
+skip_install = true
+deps =
+    readme_renderer
+    twine
+commands =
+    {envpython} -c "import os.path as osp, sys; \
+        dist_path = osp.join('{toxinidir}', 'dist'); \
+        dist_exists = osp.exists(dist_path); \
+        m = '[X] Delete the ' + dist_path + ' folder.\n' if dist_exists else ''; \
+        sys.stderr.write(m); \
+        sys.exit(int(dist_exists))"
+    {envpython} setup.py sdist
+    # TODO: this last one goes away once we ditch python 2 (via Sphinx 2.x+).
+    {envpython} setup.py bdist_wheel --universal
+    twine check dist/*
+


### PR DESCRIPTION
Sorry for this falling off my radar.  Per our original discussion goals:

- [X] Create GitHub actions CI.
- [X] Test changes to packaging via setup.py (cherry-picked relevant changes from @althonos, closes #203)
- [X] Add placeholder tests for linting (to be added later)
    - Some linting is there.  There's like no actual python code though haha.
    - The "test" is just running `sphinx-build --version`.
- [X] Make sure that demo site builds in CI.
    - Warnings and nitpicky.  Note: see changes to `examples.rst`, there seems to be a major problem with the sphinx javascript domain and linking parameters.  Just switched to C++ instead...not our problem.  AKA prefer nitpicky / warnings=error over sample js code.
- [X] Make sure we have local demo-server.
    - [ ] AFAICT it works the way you would expect.  You should double check this replaces your fabfile stuffs, and if so we'll `git rm` them.
- [ ] Test deployment to test.pypi.org for tagged releases
    - Not entirely sure how to approach this one on a PR from a fork...
    - We should use the [pypa github action](https://github.com/pypa/gh-action-pypi-publish)
    - Idea: just put this in the `dist` one, conditioned on if it's a tag.
    - Maybe we just get it setup for `test.pypyi.org`, merge, push a tag, see what happens, if works ... change to real pypi and do an actual tag (delete testing tag).
- [ ] Push things to gh-pages branch only on tagged releases.
    - I don't know github pages very well.  Was there any infrastructure for this previously?

Hope this is coherent, need to put it down for today but wanted to get this out there for review. [/dontmergeyet!]

CC: @jorisvandenbossche ref: #201 