### PR TITLE
Add overflow-wrap for sidebar

### DIFF
--- a/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
+++ b/sphinx_bootstrap_theme/bootstrap/static/bootstrap-sphinx.css_t
@@ -170,6 +170,7 @@ table.field-list {
   text-shadow: 0 1px 0 #fff;
   background-color: #f7f5fa;
   border-radius: 5px;
+  overflow-wrap: break-word;
 }
 
 /* All levels of nav */


### PR DESCRIPTION
By default overflow is handled for words separated by space.
This does not work if words are separated by other separators
such as underscore or hyphen leading to sidebar headings
and content overlap.