### PR TITLE
Remove `use_2to3` from setup configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ def read_file(name):
 setup(
     name="sphinx-bootstrap-theme",
     version=__version__,
-    use_2to3=True,
     description="Sphinx Bootstrap Theme.",
     long_description=read_file("README"),
     url="http://ryan-roemer.github.com/sphinx-bootstrap-theme/README.html",


### PR DESCRIPTION
The most recent release of `setuptools` makes builds fail, when they have this configuration. See also [their changelog](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-2). [Other projects](https://phabricator.wikimedia.org/T290451) went a similar route.

This is the error I get when trying to install this library:
```
ERROR: Command errored out with exit status 1:
    command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-ku23uxrr/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-ku23uxrr/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-zq267h8g
        cwd: /tmp/pip-req-build-ku23uxrr/
Complete output (1 lines):
error in sphinx-bootstrap-theme setup command: use_2to3 is invalid.
```