### PR TITLE
setup.cfg: Replace dash-separated options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 name = sphinx-bootstrap-theme
 version = attr: sphinx_bootstrap_theme.__version__
 author = Ryan Roemer
-author-email = ryan@loose-bits.com
-home-page = https://ryan-roemer.github.io/sphinx-bootstrap-theme/README.html
+author_email = ryan@loose-bits.com
+home_page = https://ryan-roemer.github.io/sphinx-bootstrap-theme/README.html
 description = Sphinx Bootstrap Theme.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Recent versions of setuptools report that options with names separated
by a dash (e.g. 'home-page') are deprecated and support will be
removed in later versions.